### PR TITLE
Finalize document menu structure

### DIFF
--- a/qms/views/document_views.xml
+++ b/qms/views/document_views.xml
@@ -80,7 +80,5 @@
     </record>
 
     <!-- MENU -->
-    <!-- FIXME -->
-    <menuitem id="documents_menu" name="Documents" parent="menu_qms_root" sequence="5" />
     <menuitem id="document_menu" name="Documents" parent="qms.menu_qms_main" sequence="60" />
 </odoo>


### PR DESCRIPTION
## Summary
- remove leftover documents_menu
- finalize document menu placement below ISO 9001:2015

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684156c5ac4c8330a1f74ee6c54a7e44